### PR TITLE
Allow using non-HTTPS nodes, and work with newer GHC and Pact

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -33,10 +33,10 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: 603f1523162c95742fb3e040ac065ff82f2b2aea
+    tag: 842fbc4256b3cbbde337dbeaa393b649a26f1574
 
 source-repository-package
     type: git
     location: https://github.com/kadena-io/signing-api.git
-    tag: 6975fcbff65d16a8eb8e9cde9dd7718523477251
+    tag: b60553cc61fa15c26763ca59974e0de3512b2d66
     subdir: kadena-signing-api

--- a/deps/pact/github.json
+++ b/deps/pact/github.json
@@ -3,6 +3,6 @@
   "repo": "pact",
   "branch": "master",
   "private": false,
-  "rev": "603f1523162c95742fb3e040ac065ff82f2b2aea",
-  "sha256": "0p4afnbsmm44hc4v4z4cr13h8dhnkr92zvra9rnlw7hdjrh8h2dy"
+  "rev": "842fbc4256b3cbbde337dbeaa393b649a26f1574",
+  "sha256": "0sg20svw369v5ibxxhnizfqimvxyjla0afbv8023sqcjsgc1hglc"
 }

--- a/deps/signing-api/github.json
+++ b/deps/signing-api/github.json
@@ -3,6 +3,6 @@
   "repo": "signing-api",
   "branch": "master",
   "private": false,
-  "rev": "6975fcbff65d16a8eb8e9cde9dd7718523477251",
-  "sha256": "1g2gvkc4yfv10qwrbn4d9a6rfbxwzyc7jhv1np00yx0y8kv5h3wp"
+  "rev": "b60553cc61fa15c26763ca59974e0de3512b2d66",
+  "sha256": "1xi6g67grs2dm4z4jj4l6h3lz0zy3pgi7xj2yy3y1d07m6gfwbrx"
 }

--- a/kda-tool.cabal
+++ b/kda-tool.cabal
@@ -80,6 +80,7 @@ library
     , process
     , resource-pool
     , retry
+    , safe-exceptions
     , scientific
     , servant
     , servant-client

--- a/src/Commands/WalletSign.hs
+++ b/src/Commands/WalletSign.hs
@@ -169,7 +169,7 @@ csdToSigningRequest csd = do
             gasLimit = Just $ _pmGasLimit meta
             ttl = Just $ _pmTTL meta
             sender = Just $ AccountName $ _pmSender meta
-            extraSigners = case map (PublicKey . toS . _siPubKey) $ filter (\s -> null $ _siCapList s) $ _pSigners p of
+            extraSigners = case map (PublicKeyText . toS . _siPubKey) $ filter (\s -> null $ _siCapList s) $ _pSigners p of
               [] -> Nothing
               ks -> Just ks
         pure $ SigningRequest code d caps n cid gasLimit ttl sender extraSigners


### PR DESCRIPTION
Looks like the logic for selecting HTTP vs HTTPS for a node relies on being sent an error status code when querying HTTPS, but usually you'll just get a timeout. So I just caught exceptions.