### PR TITLE
Short local output, return error code on any failure

### DIFF
--- a/src/Commands/Local.hs
+++ b/src/Commands/Local.hs
@@ -56,6 +56,5 @@ localCommand e (LocalCmdArgs args verifySigs shortOutput) = do
           if shortOutput
             then putStrLn $ toS $ encode status
             else putStrLn $ toS $ encode out
-          if all (=="success") status
-            then pure ()
-            else exitWith (ExitFailure 2)
+          when (any (/="success") status) $
+            exitWith (ExitFailure 2)

--- a/src/Commands/Local.hs
+++ b/src/Commands/Local.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Commands.Local
   ( localCommand
@@ -6,9 +7,11 @@ module Commands.Local
 
 ------------------------------------------------------------------------------
 import           Control.Error
+import           Control.Lens hiding ((.=))
 import           Control.Monad
 import           Control.Monad.Trans
 import           Data.Aeson
+import           Data.Aeson.Lens
 import           Data.Bifunctor
 import qualified Data.ByteString.Lazy as LB
 import           Data.Function
@@ -27,7 +30,7 @@ import           Utils
 ------------------------------------------------------------------------------
 
 localCommand :: Env -> LocalCmdArgs -> IO ()
-localCommand e (LocalCmdArgs args verifySigs) = do
+localCommand e (LocalCmdArgs args verifySigs shortOutput) = do
   let le = _env_logEnv e
   case _nodeTxCmdArgs_files args of
     [] -> putStrLn "No tx files specified"
@@ -47,4 +50,12 @@ localCommand e (LocalCmdArgs args verifySigs) = do
           pure $ schemeHostPortToText shp .= map responseToValue responses
       case res of
         Left er -> putStrLn er >> exitFailure
-        Right results -> putStrLn $ toS $ encode $ Object $ mconcat results
+        Right results -> do
+          let out = Object $ mconcat results
+          let status = out ^.. _Object . traverse . _Array . traverse . key "body" . key "result" . key "status" . _String
+          if shortOutput
+            then putStrLn $ toS $ encode status
+            else putStrLn $ toS $ encode out
+          if all (=="success") status
+            then pure ()
+            else exitWith (ExitFailure 2)

--- a/src/Types/Env.hs
+++ b/src/Types/Env.hs
@@ -289,8 +289,9 @@ data NodeTxCmdArgs = NodeTxCmdArgs
   } deriving (Eq,Ord,Show,Read)
 
 data LocalCmdArgs = LocalCmdArgs
-  { _nodeTxCmdArgs_txArgs :: NodeTxCmdArgs
-  , _nodeTxCmdArgs_sigVerification :: Bool
+  { _localTxCmdArgs_txArgs :: NodeTxCmdArgs
+  , _localTxCmdArgs_sigVerification :: Bool
+  , _localTxCmdArgs_shortOutput :: Bool
   } deriving (Eq,Ord,Show,Read)
 
 nodeOptP :: Parser HostPort
@@ -325,12 +326,19 @@ nodeTxCmdP :: Parser NodeTxCmdArgs
 nodeTxCmdP = NodeTxCmdArgs <$> many txFileP <*> optional schemeHostPortOptP
 
 localCmdP :: Parser LocalCmdArgs
-localCmdP = LocalCmdArgs <$> nodeTxCmdP <*> noVerifySigsP
+localCmdP = LocalCmdArgs <$> nodeTxCmdP <*> noVerifySigsP <*> shortOutputP
 
 noVerifySigsP :: Parser Bool
 noVerifySigsP = flag True False $ mconcat
   [ long "no-verify-sigs"
   , help "Don't verify signatures (useful for testing txs before signing)"
+  ]
+
+shortOutputP :: Parser Bool
+shortOutputP = flag False True $ mconcat
+  [ short 's'
+  , long "short"
+  , help "Shortened output that only shows the status"
   ]
 
 data Holes = Holes


### PR DESCRIPTION
Closes issue #12 and adds an option for shortened local output.