### PR TITLE
Support legacy YAML format

### DIFF
--- a/src/AppMain.hs
+++ b/src/AppMain.hs
@@ -63,7 +63,7 @@ appMain = do
     let theEnv = Env mgr le cd rand
     case c of
       Cut hp ma mn -> cutCommand theEnv hp ma mn
-      CombineSigs files -> combineSigsCommand theEnv files
+      CombineSigs files legacy -> combineSigsCommand theEnv files legacy
       GenTx args -> genTxCommand theEnv args
       Keygen keyType -> keygenCommand keyType
       ListKeys kf ind -> listKeysCommand kf ind
@@ -86,4 +86,3 @@ appMain = do
       , ""
       , "source <(kda --bash-completion-script `which kda`)"
       ]
-

--- a/src/Commands/CombineSigs.hs
+++ b/src/Commands/CombineSigs.hs
@@ -14,7 +14,6 @@ import           Data.List
 import           Data.Map (Map)
 import qualified Data.Map as M
 import           Data.Text (Text)
-import qualified Data.YAML.Aeson as YA
 import           Kadena.SigningTypes
 import           Katip
 import           Pact.Types.Command
@@ -28,15 +27,15 @@ import           Types.Env
 import           Utils
 ------------------------------------------------------------------------------
 
-combineSigsCommand :: Env -> [FilePath] -> IO ()
-combineSigsCommand env files = do
+combineSigsCommand :: Env -> [FilePath] -> Bool -> IO ()
+combineSigsCommand env files legacy = do
   when (not $ all hasYamlExtension files) $
     error "Error: combine-sigs files must have a .yaml extension"
 
   epairs <- mapM readCommandFile files
   case partitionEithers epairs of
     ([],ps) -> do
-      mfiles <- mapM writeCombined $ M.toList $ M.unionsWith (++) $ map mkCmdMap ps
+      mfiles <- mapM (writeCombined legacy) $ M.toList $ M.unionsWith (++) $ map mkCmdMap ps
       printf "Wrote the following files: %s\n" (intercalate ", " $ catMaybes mfiles)
     (es, _) -> do
       printf "Encountered errors in the following files: %s\n" (intercalate ", " $ map fst es)
@@ -45,15 +44,15 @@ combineSigsCommand env files = do
 mkCmdMap :: (FilePath, CommandSigData) -> Map Text [(FilePath, SignatureList)]
 mkCmdMap (fp, csd) = M.singleton (_csd_cmd csd) [(fp, _csd_sigs csd)]
 
-writeCombined :: (Text, [(FilePath, SignatureList)]) -> IO (Maybe FilePath)
-writeCombined (_, []) = pure Nothing
-writeCombined (cmd, fsigs@(p:ps)) = do
+writeCombined :: Bool -> (Text, [(FilePath, SignatureList)]) -> IO (Maybe FilePath)
+writeCombined _ (_, []) = pure Nothing
+writeCombined legacy (cmd, fsigs@(p:ps)) = do
   let (fname,sigs) = case ps of
         [] -> (dropExtension $ fst p, snd p)
         _ ->
           let fp = intercalate "-" (sort $ map (dropExtension . takeFileName . fst) fsigs)
           in (fp, combineSigs $ map snd fsigs)
-  fp <- saveCommandSigData fname $ CommandSigData sigs cmd
+  fp <- saveCommandSigData fname (CommandSigData sigs cmd) legacy
   pure $ Just fp
 
 combineSigs :: [SignatureList] -> SignatureList
@@ -71,5 +70,5 @@ readCommandFile fp = do
   h <- openFile fp ReadMode
   rawbs <- readAsEncoding Yaml h
   hClose h
-  let eres = YA.decode1Strict rawbs
-  pure $ bimap (\e -> (fp, show e)) (fp,) eres
+  let eres = decodeCmdYaml rawbs
+  pure $ bimap (\e -> (fp, e)) (fp,) eres

--- a/src/Commands/WalletSign.hs
+++ b/src/Commands/WalletSign.hs
@@ -95,7 +95,7 @@ signYamlFiles env args = do
                     case _csdr_outcome csdr of
                       SO_Success _ -> do
                         let c2 = _csdr_csd csdr
-                        f2 <- saveCommandSigData (dropExtension f) c2
+                        f2 <- saveCommandSigData (dropExtension f) c2 False
                         pure (f2, countSigs c2 - countSigs c1)
                       SO_Failure msg -> do
                         T.putStrLn $ "Got signing failure: " <> msg

--- a/src/Types/Env.hs
+++ b/src/Types/Env.hs
@@ -447,7 +447,7 @@ oldP = flag False True $ mconcat
   ]
 
 data SubCommand
-  = CombineSigs [FilePath]
+  = CombineSigs [FilePath] Bool
   | Cut SchemeHostPort (Maybe Text) (Maybe Text)
   | GenTx GenTxArgs
   | Keygen KeyType
@@ -546,7 +546,7 @@ templateCommands = mconcat
 
 signingCommands :: Mod CommandFields SubCommand
 signingCommands = mconcat
-  [ command "combine-sigs" (info (CombineSigs <$> many txFileP)
+  [ command "combine-sigs" (info (CombineSigs <$> many txFileP <*> legacyOutputP)
       (progDesc "Combine signatures from multiple files"))
   , command "sign" (info (Sign <$> signP)
       (progDesc "Sign transactions"))
@@ -557,6 +557,11 @@ signingCommands = mconcat
   , commandGroup "Transaction Signing Commands"
   , hidden
   ]
+
+legacyOutputP :: Parser Bool
+legacyOutputP = switch $ mconcat
+  [ short 'l'
+  , help "Output legacy YAML format" ]
 
 apiVerP :: Parser Text
 apiVerP = strArgument $ mconcat


### PR DESCRIPTION
Support legacy format to integrate with Chainweaver and pact CLI tools.

- On input, try current format, when that fails, try legacy format (`sign`, `combine-sigs` commands)
- In `combine-sigs`, accept `-l` switch to output in legacy format. 

This allows workflows like the following:
1. Author a safe transfer in Chainweaver that needs three sigs, two offline.
2. Send legacy YAML from Chainweaver to first kda-tool offline signer. Output is current format.
3. Send current YAML to second kda-tool offline signer. Output is in current format.
4. Second signer uses `combine-sigs` to convert to legacy format and sends to final Chainweaver signer.
5. Final Chainweaver signer puts YAML in SigBuilder, signs and sends to network.

Note that since `combine-sigs` accepts both old and new formats, steps 2-5 could happen asynchronously and have a kda-tool user combine outputs and send.

I've tested roundtripping with old and new formats.