### PR TITLE
Migrate to hs-nix-infra for the Nix setup

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -42,5 +42,6 @@ jobs:
         echo Building the project
         nix build .#check --log-lines 500 --show-trace
 
-        echo Build the recursive output
+        echo Build the recursive outputs
         nix build .#recursive.allDerivations --log-lines 500 --show-trace
+        nix build .#bundled.recursive.allDerivations --log-lines 500 --show-trace

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,10 +21,11 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache/by-root@v3
+      uses: kadena-io/setup-nix-with-cache/by-root@v3.1
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
+        additional_experimental_features: recursive-nix
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
@@ -34,9 +35,12 @@ jobs:
         aws-region: us-east-1
 
     - name: Give root user AWS credentials
-      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3
+      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3.1
 
     - name: Build and cache artifacts
       run: |
         echo Building the project
         nix build .#check --log-lines 500 --show-trace
+
+        echo Build the recursive output
+        nix build .#recursive.allDerivations --log-lines 500 --show-trace

--- a/flake.lock
+++ b/flake.lock
@@ -1,89 +1,37 @@
 {
   "nodes": {
-    "HTTP": {
+    "empty": {
       "flake": false,
       "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "lastModified": 1683033565,
+        "narHash": "sha256-UZ2dz7/RzJKTw/8uqLu6biAbb3xNk23xUHb5/oAYWsw=",
+        "owner": "kadena-io",
+        "repo": "empty",
+        "rev": "c30c041f692678788a294069c95677774be2dff3",
         "type": "github"
       },
       "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645834128,
-        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669081697,
-        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
+        "owner": "kadena-io",
+        "repo": "empty",
         "type": "github"
       }
     },
     "flake-compat": {
+      "locked": {
+        "lastModified": 1699384378,
+        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
+        "owner": "kadena-io",
+        "repo": "flake-compat",
+        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kadena-io",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -118,31 +66,14 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1694132703,
-        "narHash": "sha256-44c+OKSxUVAJ3hpFuNuNy1CG54iOkWJy/CHYyPx/NXk=",
+        "lastModified": 1696379114,
+        "narHash": "sha256-dtax/ci3JfYvR2lLsvpvC6b3NCoEGZLrDH21/2svTps=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b7ff2a816ad540e7c6ab5b0c9a5567e041aac6aa",
+        "rev": "21eae6f46c91831741496101e541e628aadecd98",
         "type": "github"
       },
       "original": {
@@ -153,189 +84,158 @@
     },
     "haskellNix": {
       "inputs": {
-        "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
-        "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
-        "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": "hackage",
-        "hls-1.10": "hls-1.10",
-        "hls-2.0": "hls-2.0",
-        "hls-2.2": "hls-2.2",
-        "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
-        "iserv-proxy": "iserv-proxy",
+        "HTTP": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-32": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-34": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-36": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cardano-shell": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "flake-compat": "flake-compat_2",
+        "ghc-8.6.5-iohk": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "ghc980": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "ghc99": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hackage": [
+          "hs-nix-infra",
+          "hackage"
+        ],
+        "hls-1.10": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.0": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.2": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.3": "hls-2.3",
+        "hpc-coveralls": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hydra": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "iserv-proxy": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs": [
+          "hs-nix-infra",
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
-        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2003": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2105": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2111": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2205": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2211": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2305": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage"
-      },
-      "locked": {
-        "lastModified": 1694159332,
-        "narHash": "sha256-Pxbgf2kv6IOqHqSk99F/GHnzI9hdym95dn9qrdpQsQY=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "3e4262ca9692c999df1eb8d826b82705da868bdf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
-    "hls-1.10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680000865,
-        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693064058,
-        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.2.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hpc-coveralls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
+        "old-ghc-nix": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "stackage": [
+          "hs-nix-infra",
+          "empty"
         ]
       },
       "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "lastModified": 1697195891,
+        "narHash": "sha256-0L803S/wcHmVebEwFxObYCYOaB14ZtBAFCdg0aRgH70=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "c6cb3ff56b001b211690da35f70827fab5bf3272",
         "type": "github"
       },
       "original": {
-        "id": "hydra",
-        "type": "indirect"
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
       }
     },
-    "iserv-proxy": {
+    "hls-2.3": {
       "flake": false,
       "locked": {
-        "lastModified": 1688517130,
-        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
-        "ref": "hkm/remote-iserv",
-        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
-        "revCount": 13,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      },
-      "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
         "type": "github"
       },
       "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
-    "nix": {
+    "hs-nix-infra": {
       "inputs": {
-        "lowdown-src": "lowdown-src",
+        "empty": "empty",
+        "flake-compat": "flake-compat",
+        "hackage": "hackage",
+        "haskellNix": "haskellNix",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
+        "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "lastModified": 1699970998,
+        "narHash": "sha256-NgvBCRIB+lvcxJWMpU8Mulx8PG8s5jtqSR8K/natoTA=",
+        "owner": "kadena-io",
+        "repo": "hs-nix-infra",
+        "rev": "a69071dafa3f0d12edf30ecc5a562aee1f7d138d",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
+        "owner": "kadena-io",
+        "repo": "hs-nix-infra",
         "type": "github"
       }
     },
@@ -357,139 +257,43 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
         "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       }
     },
-    "nixpkgs-2003": {
+    "nixpkgs-rec": {
       "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2305": {
-      "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690720142,
-        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {
@@ -499,48 +303,11 @@
         "type": "github"
       }
     },
-    "old-ghc-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "haskellNix": "haskellNix",
-        "nix-exe-bundle": "nix-exe-bundle",
-        "nixpkgs": [
-          "haskellNix",
-          "nixpkgs-unstable"
-        ]
-      }
-    },
-    "stackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1694045350,
-        "narHash": "sha256-bNRNObJHGM12ytmga//zcAQetftBYTFOAj+WtUbgvn8=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "39e4b93efff05aa64733655fdbbd88205d099fff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
+        "hs-nix-infra": "hs-nix-infra",
+        "nix-exe-bundle": "nix-exe-bundle"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,11 +34,16 @@
         echo ${name}: ${package}
         echo works > $out
       '';
+      default = flake.packages."kda-tool:exe:kda";
+      bundled = (pkgs.callPackage inputs.nix-exe-bundle {} default).overrideAttrs
+        (_: {inherit (default) version;});
     in flake // {
       # Built by `nix build .`
       packages = rec {
-        default = flake.packages."kda-tool:exe:kda";
-        bundled = pkgs.callPackage inputs.nix-exe-bundle {} default;
+        inherit default bundled;
+        recursive = with hs-nix-infra.lib.recursive system;
+          wrapRecursiveWithMeta "kda" "${wrapFlake self}.default";
+
         check = pkgs.runCommand "check" {} ''
           echo ${default}
           echo ${mkCheck "devShell" flake.devShell}

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,11 @@
         echo works > $out
       '';
       default = flake.packages."kda-tool:exe:kda";
-      bundled = (pkgs.callPackage inputs.nix-exe-bundle {} default).overrideAttrs
-        (_: {inherit (default) version;});
+      bundled = (pkgs.callPackage inputs.nix-exe-bundle {} default).overrideAttrs (_: {
+        inherit (default) version;
+        passthru.recursive = with hs-nix-infra.lib.recursive system;
+          wrapRecursiveWithMeta "kda" "${wrapFlake self}.packages.${system}.bundled";
+      });
     in {
       # Built by `nix build .`
       packages = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,11 @@
 {
-  inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
-  inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  inputs.hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nix-exe-bundle = { url = "github:3noch/nix-bundle-exe"; flake = false; };
-  outputs = inputs@{ self, nixpkgs, flake-utils, haskellNix, ...}:
+  outputs = inputs@{ self, flake-utils, hs-nix-infra, ...}:
     flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ] (system:
     let
+      inherit (hs-nix-infra) haskellNix nixpkgs;
       overlays = [ haskellNix.overlay
         (final: prev: {
           # This overlay adds our project to pkgs

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,8 @@
         })
       ];
       pkgs = import nixpkgs { inherit system overlays; inherit (haskellNix) config; };
-      flake = pkgs.kdaToolProject.flake {
+      project = pkgs.kdaToolProject;
+      flake = project.flake {
         # This adds support for `nix build .#js-unknown-ghcjs:hello:exe:hello`
         # crossPlatforms = p: [p.ghcjs];
       };
@@ -37,7 +38,7 @@
       default = flake.packages."kda-tool:exe:kda";
       bundled = (pkgs.callPackage inputs.nix-exe-bundle {} default).overrideAttrs
         (_: {inherit (default) version;});
-    in flake // {
+    in {
       # Built by `nix build .`
       packages = rec {
         inherit default bundled;
@@ -50,5 +51,11 @@
           echo works > $out
         '';
       };
+
+      inherit (flake) devShell;
+
+      # Other flake outputs provided by haskellNix can be accessed through
+      # this project output
+      inherit project;
     });
 }


### PR DESCRIPTION
This PR does the following:

## Unify the GHC derivation used across Kadena projects

Instead of depending on `nixpkgs` and `haskellNix` directly, this flake now depends on our new `hs-nix-infra` flake and uses the `nixpkgs` and `haskellNix` revisions provided by it. The hash of the `nixpkgs` and `haskellNix` flakes used for defining the `haskell.nix` `project` determines the hash of the GHC package that gets used to compile the Haskell modules.  

When multiple projects depend on `nixpkgs` and `haskellNix` independently, it's very hard (and not really well supported by nix CLI) to make sure that they don't deviate from each others' `nixpkgs` and `haskellNix` pins arbitrarily. I.e. updating two projects' `flake.lock` files at slightly different times is likely to cause one of the pins to be on a different revision, even though the difference doesn't matter functionally.

These unnecessarily different GHC packages put a lot of pressure on our CI infrastructure, taking hours to build functionally equivalent GHC packages and bloating the cache (with binaries from all the architectures we build and cache for). That also bloats the `/nix/store` of any `chainweb-data` user that wants to `nix build` an uncached `chainweb-data` version.

### The new workflow for updating Haskell-Nix toolchain

After this PR, the new workflow for managing our Haskell dependencies used by Nix will involve the following steps:
* If an update to the toolchain is needed in order to fix the build, the first thing to try is to bump the `hs-nix-infra` dependency of this flake to the latest version. If that's not enough, we need to open a PR to `hs-nix-infra` to bump its proper input:
    * If we need to update our hackage pin so that we can build with newly released Haskell packages, we can just `nix flake lock --update-input hackage` and get a newer hackage snapshot without needing to introduce a new GHC derivation.
    * If we need to use a new GHC version provided by a newer `nixpkgs` version or if we need to bump our `haskellNix` pin for any reason we need to bump `nixpkgs` and `haskellNix`. The PR would preferably bump both of them to the latest version.

Hopefully, this new workflow will reduce the number of `nixpkgs` + `haskellNix` versions we depend on across our Haskell projects.

## Add a `recursive` alternative to the `default` package

As part of the CI automation for this repo, we're building and caching the Nix binaries for `chainweb-data`, which makes it convenient for any user to `nix build` chainweb-data from any commit/branch since all the dependencies will come from our binary cache. However, even without building anything locally, *evaluating* the `default` package of this flake takes a significant amount of time and involves downloading ~2 GB of Nix dependencies. This is due to the complexity of what `haskellNix` does for us at Nix evaluation time.

This PR introduces a `recursive` package to this flake's output, which uses `recursive-nix` to push the Nix evaluation of the `default` package into the build of a derivation. This means, any user that tries to `nix build .#recursive` will fetch the chainweb-data binary from our cache without having to perform any complex Nix evaluation locally or downloading the Nix dependencies of any such evaluation as long as the `recursive` derivation they're building is already in our binary cache. If not, the `recursive-nix` derivation will be built locally (in which case make sure your local Nix setup has `recursive-nix` enabled), which is essentially as much work as building `default` itself. This might still be worthwhile however, since subsequent builds of the same `recursive` derivation will complete immediately, without having to evaluate the `default` derivation again.
